### PR TITLE
[RFR] US20 - Allow variations in response syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "json-loader": "0.5.4",
     "lodash.omit": "^4.5.0",
     "mocha": "3.1.2",
+    "nlp_compromise": "6.5.3",
     "serverless": "1.1.0",
     "serverless-offline": "3.4.1",
     "serverless-webpack": "1.0.0-rc.2",

--- a/src/serverless/botConversation/getNbCigarettes.js
+++ b/src/serverless/botConversation/getNbCigarettes.js
@@ -1,5 +1,8 @@
+import { value } from 'nlp_compromise';
+
 export default function getNbCigarettes(message) {
-    const nbCigarettes = parseInt(message, 10);
+    const nbCigarettes = parseInt(value(message).number, 10);
+
     if (isNaN(nbCigarettes)) {
         return null;
     }

--- a/src/serverless/botConversation/getNbCigarettes.spec.js
+++ b/src/serverless/botConversation/getNbCigarettes.spec.js
@@ -9,7 +9,37 @@ describe('getNbCigarettes', () => {
         expect(nbCigarettes).toEqual(13);
     });
 
-    it('should set user state to dubious if message is not a number', () => {
+    it('should getNbCigarettes if message is a number variation (about)', () => {
+        const nbCigarettes = getNbCigarettes('about 13');
+
+        expect(nbCigarettes).toEqual(13);
+    });
+
+    it('should getNbCigarettes if message is a number variation (less than)', () => {
+        const nbCigarettes = getNbCigarettes('less than 13');
+
+        expect(nbCigarettes).toEqual(13);
+    });
+
+    it('should getNbCigarettes if message is a number variation (more than)', () => {
+        const nbCigarettes = getNbCigarettes('more than 13');
+
+        expect(nbCigarettes).toEqual(13);
+    });
+
+    it('should getNbCigarettes if message is a number variation (X cigarettes)', () => {
+        const nbCigarettes = getNbCigarettes('13 cigarettes');
+
+        expect(nbCigarettes).toEqual(13);
+    });
+
+    it('should getNbCigarettes if message is a number variation (thirteen)', () => {
+        const nbCigarettes = getNbCigarettes('thirteen');
+
+        expect(nbCigarettes).toEqual(13);
+    });
+
+    it('should return null if message is not a number', () => {
         const nbCigarettes = getNbCigarettes('I do not know');
         expect(nbCigarettes).toBe(null);
     });


### PR DESCRIPTION
[Trello card](https://trello.com/c/5hbCuVCD/20-allow-variations-in-response-syntax)

Uses [nlp-compromise](https://github.com/nlp-compromise/nlp_compromise) to analyse messages